### PR TITLE
add budget and transaction pages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,13 @@
 # Exit when any command fails
 set -e
 
+# Run Next.js TypeScript type checking
+echo "🔍 Checking TypeScript types..."
+npm run typecheck
+
+# Run linting, formatting and tests
 npm run lint
 npm run format
 npm test
+
+echo "✅ Commit validated successfully!"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Improve a users net worth by making it easier for them to see where they are spe
 
 1. Clone the repository: `git clone https://github.com/JRRS1982/balanced.git`
 2. Update the environment variables in the `.env.development` file
-3. Run `npm install` to install dependencies
-4. Run `npm run dev` to start the development server and visit <http://localhost:3000> OR `npm run docker:dev` to start the development server in a docker container and visit <http://localhost:3000> which is probably the better option.
-5. You should then be able to navigate around the application and create a user / login using Auth0
+3. Run `npm run docker:dev` to start the development server in a docker container and visit <http://localhost:3000>, or `npm install` and `npm run dev` to start the development server locally and visit <http://localhost:3000>
+4. You should then be able to navigate around the application and create a user / login using Auth0
 
 ## Technologies Used
 

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -47,7 +47,7 @@ services:
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${DB_USER} -d ${DB_NAME}']
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -47,7 +47,7 @@ services:
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      test: ['CMD-SHELL', 'pg_isready -U ${DB_USER} -d ${DB_NAME}']
       interval: 5s
       timeout: 5s
       retries: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "15.3.2",
         "prisma": "^6.7.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "recharts": "^2.15.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -472,6 +473,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2414,6 +2423,60 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -3946,6 +4009,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4202,8 +4273,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
       "version": "14.4.0",
@@ -4340,6 +4410,116 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4430,6 +4610,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/dedent": {
       "version": "1.6.0",
@@ -4549,6 +4734,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -5343,6 +5537,11 @@
       "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
       "dev": true
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/eventsource": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
@@ -5536,6 +5735,14 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -6356,6 +6563,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -7483,8 +7698,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -7724,8 +7938,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7808,7 +8021,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8100,7 +8312,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8699,7 +8910,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8841,8 +9051,71 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -9769,6 +10042,11 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
@@ -10233,6 +10511,27 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "format": "prettier --write .",
     "test": "jest",
+    "typecheck": "tsc --noEmit",
     "docker:dev:build": "docker compose -f compose.dev.yml --env-file .env.development build",
     "docker:dev:up": "docker compose -f compose.dev.yml --env-file .env.development up",
     "docker:dev:down": "docker compose -f compose.dev.yml --env-file .env.development down --remove-orphans && docker image prune -f",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "next": "15.3.2",
     "prisma": "^6.7.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "recharts": "^2.15.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/budget/budget.module.css
+++ b/src/app/budget/budget.module.css
@@ -1,0 +1,155 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+.mainSection {
+  margin-bottom: 3rem;
+}
+
+.mainSectionTitle {
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #333;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #0070f3;
+  margin-bottom: 1.5rem;
+}
+
+.subsection {
+  margin-bottom: 2rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.subsectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.subsectionName {
+  font-size: 1.2rem;
+  font-weight: bold;
+  padding: 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  width: 300px;
+}
+
+.subsectionName:focus {
+  border-color: #0070f3;
+  outline: none;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.table th {
+  background-color: #f9f9f9;
+  font-weight: bold;
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.input:focus {
+  border-color: #0070f3;
+  outline: none;
+}
+
+.addButton {
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin: 0.5rem 0;
+  font-weight: 500;
+}
+
+.addButton:hover {
+  background-color: #0060df;
+}
+
+.removeButton {
+  background-color: #ff4040;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.removeButton:hover {
+  background-color: #e53030;
+}
+
+.mainSectionTotal {
+  margin-top: 1rem;
+  text-align: right;
+  font-size: 1.2rem;
+  padding: 0.5rem 1rem;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+}
+
+.summary {
+  margin-top: 3rem;
+  padding: 1.5rem;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.summaryItem {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+  font-size: 1.2rem;
+  font-weight: 500;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.summaryItem:last-child {
+  font-size: 1.5rem;
+  font-weight: bold;
+  border-bottom: none;
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+  border-top: 2px solid #e0e0e0;
+}
+
+.positive {
+  color: #28a745;
+}
+
+.negative {
+  color: #dc3545;
+}

--- a/src/app/budget/mockData.ts
+++ b/src/app/budget/mockData.ts
@@ -1,0 +1,101 @@
+import { BudgetCategory } from '../transactions/types';
+import { BudgetMainSection } from './types';
+
+// Sample budget data (for development purposes)
+// TODO: Replace with actual budget data
+export const sampleBudgetData: BudgetCategory[] = [
+  { category: 'Salary', budgeted: 5000, type: 'income' },
+  { category: 'Investments', budgeted: 500, type: 'income' },
+  { category: 'Bonus', budgeted: 1000, type: 'income' },
+  { category: 'Housing', budgeted: 1500, type: 'expense' },
+  { category: 'Food', budgeted: 600, type: 'expense' },
+  { category: 'Transportation', budgeted: 300, type: 'expense' },
+  { category: 'Utilities', budgeted: 200, type: 'expense' },
+  { category: 'Entertainment', budgeted: 200, type: 'expense' },
+  { category: 'Healthcare', budgeted: 150, type: 'expense' },
+  { category: 'Shopping', budgeted: 300, type: 'expense' },
+];
+
+// Sample budget sections (for development purposes)
+// TODO: Replace with actual budget sections
+export const sampleBudgetSections: BudgetMainSection[] = [
+  {
+    id: 'income',
+    name: 'Income',
+    subsections: [
+      {
+        id: 'income-1',
+        name: 'Primary Income',
+        rows: [
+          { id: 'income-1-1', description: 'Salary', amount: 5000 },
+          { id: 'income-1-2', description: 'Bonus', amount: 1000 },
+        ],
+      },
+      {
+        id: 'income-2',
+        name: 'Secondary Income',
+        rows: [
+          { id: 'income-2-1', description: 'Investments', amount: 500 },
+          { id: 'income-2-2', description: 'Side Projects', amount: 300 },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'expenses',
+    name: 'Expenses',
+    subsections: [
+      {
+        id: 'expenses-1',
+        name: 'Housing',
+        rows: [
+          { id: 'expenses-1-1', description: 'Rent', amount: 1500 },
+          { id: 'expenses-1-2', description: 'Utilities', amount: 200 },
+        ],
+      },
+      {
+        id: 'expenses-2',
+        name: 'Food',
+        rows: [
+          { id: 'expenses-2-1', description: 'Groceries', amount: 400 },
+          { id: 'expenses-2-2', description: 'Dining Out', amount: 200 },
+        ],
+      },
+      {
+        id: 'expenses-3',
+        name: 'Transportation',
+        rows: [
+          { id: 'expenses-3-1', description: 'Gas', amount: 150 },
+          { id: 'expenses-3-2', description: 'Public Transit', amount: 100 },
+          { id: 'expenses-3-3', description: 'Car Maintenance', amount: 50 },
+        ],
+      },
+      {
+        id: 'expenses-4',
+        name: 'Entertainment',
+        rows: [
+          { id: 'expenses-4-1', description: 'Streaming Services', amount: 50 },
+          { id: 'expenses-4-2', description: 'Movies/Events', amount: 100 },
+          { id: 'expenses-4-3', description: 'Hobbies', amount: 50 },
+        ],
+      },
+      {
+        id: 'expenses-5',
+        name: 'Healthcare',
+        rows: [
+          { id: 'expenses-5-1', description: 'Insurance', amount: 100 },
+          { id: 'expenses-5-2', description: 'Medications', amount: 50 },
+        ],
+      },
+      {
+        id: 'expenses-6',
+        name: 'Shopping',
+        rows: [
+          { id: 'expenses-6-1', description: 'Clothing', amount: 150 },
+          { id: 'expenses-6-2', description: 'Electronics', amount: 100 },
+          { id: 'expenses-6-3', description: 'Household Items', amount: 50 },
+        ],
+      },
+    ],
+  },
+];

--- a/src/app/budget/page.tsx
+++ b/src/app/budget/page.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './budget.module.css';
+import { BudgetMainSection, BudgetSubsection, BudgetRow } from './types';
+import { sampleBudgetSections } from './mockData';
+
+export default function BudgetPage() {
+  // State for main budget sections (Income and Expenses)
+  const [mainSections, setMainSections] = useState<BudgetMainSection[]>(sampleBudgetSections);
+
+  // Function to add a new subsection to a main section
+  const addSubsection = (mainSectionId: string) => {
+    setMainSections(
+      mainSections.map(mainSection => {
+        if (mainSection.id === mainSectionId) {
+          const newSubsectionId = `${mainSectionId}-${mainSection.subsections.length + 1}`;
+          return {
+            ...mainSection,
+            subsections: [
+              ...mainSection.subsections,
+              {
+                id: newSubsectionId,
+                name: `New ${mainSection.name} Category`,
+                rows: [],
+              },
+            ],
+          };
+        }
+        return mainSection;
+      })
+    );
+  };
+
+  // Function to remove a subsection
+  const removeSubsection = (mainSectionId: string, subsectionId: string) => {
+    setMainSections(
+      mainSections.map(mainSection => {
+        if (mainSection.id === mainSectionId) {
+          return {
+            ...mainSection,
+            subsections: mainSection.subsections.filter(
+              subsection => subsection.id !== subsectionId
+            ),
+          };
+        }
+        return mainSection;
+      })
+    );
+  };
+
+  // Function to update a subsection name
+  const updateSubsectionName = (mainSectionId: string, subsectionId: string, newName: string) => {
+    setMainSections(
+      mainSections.map(mainSection => {
+        if (mainSection.id === mainSectionId) {
+          return {
+            ...mainSection,
+            subsections: mainSection.subsections.map(subsection =>
+              subsection.id === subsectionId ? { ...subsection, name: newName } : subsection
+            ),
+          };
+        }
+        return mainSection;
+      })
+    );
+  };
+
+  // Function to add a row to a subsection
+  const addRow = (mainSectionId: string, subsectionId: string) => {
+    setMainSections(
+      mainSections.map(mainSection => {
+        if (mainSection.id === mainSectionId) {
+          return {
+            ...mainSection,
+            subsections: mainSection.subsections.map(subsection => {
+              if (subsection.id === subsectionId) {
+                const newRowId = `${subsectionId}-${subsection.rows.length + 1}`;
+                return {
+                  ...subsection,
+                  rows: [...subsection.rows, { id: newRowId, description: 'New Item', amount: 0 }],
+                };
+              }
+              return subsection;
+            }),
+          };
+        }
+        return mainSection;
+      })
+    );
+  };
+
+  // Function to remove a row from a subsection
+  const removeRow = (mainSectionId: string, subsectionId: string, rowId: string) => {
+    setMainSections(
+      mainSections.map(mainSection => {
+        if (mainSection.id === mainSectionId) {
+          return {
+            ...mainSection,
+            subsections: mainSection.subsections.map(subsection => {
+              if (subsection.id === subsectionId) {
+                return {
+                  ...subsection,
+                  rows: subsection.rows.filter(row => row.id !== rowId),
+                };
+              }
+              return subsection;
+            }),
+          };
+        }
+        return mainSection;
+      })
+    );
+  };
+
+  // Function to update a row
+  const updateRow = (
+    mainSectionId: string,
+    subsectionId: string,
+    rowId: string,
+    field: keyof BudgetRow,
+    value: string | number
+  ) => {
+    setMainSections(
+      mainSections.map(mainSection => {
+        if (mainSection.id === mainSectionId) {
+          return {
+            ...mainSection,
+            subsections: mainSection.subsections.map(subsection => {
+              if (subsection.id === subsectionId) {
+                return {
+                  ...subsection,
+                  rows: subsection.rows.map(row => {
+                    if (row.id === rowId) {
+                      return { ...row, [field]: value };
+                    }
+                    return row;
+                  }),
+                };
+              }
+              return subsection;
+            }),
+          };
+        }
+        return mainSection;
+      })
+    );
+  };
+
+  // Calculate total for a subsection
+  const calculateSubsectionTotal = (subsection: BudgetSubsection) => {
+    return subsection.rows.reduce((total, row) => total + row.amount, 0);
+  };
+
+  // Calculate total for a main section (sum of all subsections)
+  const calculateMainSectionTotal = (mainSection: BudgetMainSection) => {
+    return mainSection.subsections.reduce(
+      (total, subsection) => total + calculateSubsectionTotal(subsection),
+      0
+    );
+  };
+
+  // Calculate income total
+  const calculateIncomeTotal = () => {
+    const incomeSection = mainSections.find(section => section.id === 'income');
+    return incomeSection ? calculateMainSectionTotal(incomeSection) : 0;
+  };
+
+  // Calculate expenses total
+  const calculateExpensesTotal = () => {
+    const expensesSection = mainSections.find(section => section.id === 'expenses');
+    return expensesSection ? calculateMainSectionTotal(expensesSection) : 0;
+  };
+
+  // Calculate net income (income - expenses)
+  const calculateNetIncome = () => {
+    return calculateIncomeTotal() - calculateExpensesTotal();
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Budget Planner</h1>
+
+      {mainSections.map(mainSection => (
+        <div key={mainSection.id} className={styles.mainSection}>
+          <h2 className={styles.mainSectionTitle}>{mainSection.name}</h2>
+
+          <button className={styles.addButton} onClick={() => addSubsection(mainSection.id)}>
+            Add New {mainSection.name} Category
+          </button>
+
+          {mainSection.subsections.map(subsection => (
+            <div key={subsection.id} className={styles.subsection}>
+              <div className={styles.subsectionHeader}>
+                <input
+                  type="text"
+                  value={subsection.name}
+                  onChange={e =>
+                    updateSubsectionName(mainSection.id, subsection.id, e.target.value)
+                  }
+                  className={styles.subsectionName}
+                />
+                <button
+                  className={styles.removeButton}
+                  onClick={() => removeSubsection(mainSection.id, subsection.id)}
+                >
+                  Remove Category
+                </button>
+              </div>
+
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Description</th>
+                    <th>Amount</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {subsection.rows.map(row => (
+                    <tr key={row.id}>
+                      <td>
+                        <input
+                          type="text"
+                          value={row.description}
+                          onChange={e =>
+                            updateRow(
+                              mainSection.id,
+                              subsection.id,
+                              row.id,
+                              'description',
+                              e.target.value
+                            )
+                          }
+                          className={styles.input}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="number"
+                          value={row.amount}
+                          onChange={e =>
+                            updateRow(
+                              mainSection.id,
+                              subsection.id,
+                              row.id,
+                              'amount',
+                              parseFloat(e.target.value) || 0
+                            )
+                          }
+                          className={styles.input}
+                        />
+                      </td>
+                      <td>
+                        <button
+                          className={styles.removeButton}
+                          onClick={() => removeRow(mainSection.id, subsection.id, row.id)}
+                        >
+                          Remove
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td colSpan={3}>
+                      <button
+                        className={styles.addButton}
+                        onClick={() => addRow(mainSection.id, subsection.id)}
+                      >
+                        Add Item
+                      </button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Category Total:</td>
+                    <td colSpan={2}>${calculateSubsectionTotal(subsection).toFixed(2)}</td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          ))}
+
+          <div className={styles.mainSectionTotal}>
+            <h3>
+              {mainSection.name} Total: ${calculateMainSectionTotal(mainSection).toFixed(2)}
+            </h3>
+          </div>
+        </div>
+      ))}
+
+      <div className={styles.summary}>
+        <div className={styles.summaryItem}>
+          <span>Total Income:</span>
+          <span>${calculateIncomeTotal().toFixed(2)}</span>
+        </div>
+        <div className={styles.summaryItem}>
+          <span>Total Expenses:</span>
+          <span>${calculateExpensesTotal().toFixed(2)}</span>
+        </div>
+        <div
+          className={`${styles.summaryItem} ${calculateNetIncome() >= 0 ? styles.positive : styles.negative}`}
+        >
+          <span>Net Income:</span>
+          <span>${calculateNetIncome().toFixed(2)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/budget/types.ts
+++ b/src/app/budget/types.ts
@@ -1,0 +1,26 @@
+// Budget-related types
+
+export interface BudgetRow {
+  id: string;
+  description: string;
+  amount: number;
+}
+
+export interface BudgetSubsection {
+  id: string;
+  name: string;
+  rows: BudgetRow[];
+}
+
+export interface BudgetMainSection {
+  id: string;
+  name: string; // 'Income' or 'Expenses'
+  subsections: BudgetSubsection[];
+}
+
+// Budget category type shared with transactions page
+export interface BudgetCategory {
+  category: string;
+  budgeted: number;
+  type: 'income' | 'expense';
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import Navigation from '@/components/Navigation';
 import './globals.css';
 
 const geistSans = Geist({
@@ -24,7 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        <Navigation />
+        <main>{children}</main>
+      </body>
     </html>
   );
 }

--- a/src/app/transactions/helpers.ts
+++ b/src/app/transactions/helpers.ts
@@ -15,8 +15,9 @@ export const isCurrentMonth = (dateString: string): boolean => {
     if (isNaN(date.getTime())) return false;
 
     return date.getMonth() === now.getMonth() && date.getFullYear() === now.getFullYear();
-  } catch (e) {
-    console.error(`Invalid date: ${dateString}, error: ${e.message}`);
+  } catch (e: unknown) {
+    const error = e as Error;
+    console.error(`Invalid date: ${dateString}, error: ${error.message}`);
     return false;
   }
 };
@@ -31,8 +32,9 @@ export const formatDateToISOString = (date: string | Date): string => {
       throw new Error('Invalid date');
     }
     return dateObj.toISOString().split('T')[0];
-  } catch (e) {
-    console.error(`Error formatting date: ${date}, error: ${e.message}`);
+  } catch (e: unknown) {
+    const error = e as Error;
+    console.error(`Error formatting date: ${date}, error: ${error.message}`);
     return '';
   }
 };
@@ -73,8 +75,9 @@ export const standardizeDateFormat = (dateString: string): string => {
       return parsedDate.toISOString().split('T')[0];
     }
     return dateString; // Return original if parsing fails
-  } catch (e) {
-    console.error(`Error parsing transaction date: ${dateString}, error: ${e.message}`);
+  } catch (e: unknown) {
+    const error = e as Error;
+    console.error(`Error parsing transaction date: ${dateString}, error: ${error.message}`);
     return dateString; // Return original if error occurs
   }
 };

--- a/src/app/transactions/helpers.ts
+++ b/src/app/transactions/helpers.ts
@@ -1,0 +1,80 @@
+// Date-related helper functions
+
+/**
+ * Checks if a date string represents a date in the current month and year
+ */
+export const isCurrentMonth = (dateString: string): boolean => {
+  // First ensure the date is valid
+  if (!dateString) return false;
+
+  try {
+    const date = new Date(dateString);
+    const now = new Date();
+
+    // Check if the date is valid
+    if (isNaN(date.getTime())) return false;
+
+    return date.getMonth() === now.getMonth() && date.getFullYear() === now.getFullYear();
+  } catch (e) {
+    console.error(`Invalid date: ${dateString}, error: ${e.message}`);
+    return false;
+  }
+};
+
+/**
+ * Formats a date string or Date object to ISO format YYYY-MM-DD
+ */
+export const formatDateToISOString = (date: string | Date): string => {
+  try {
+    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    if (isNaN(dateObj.getTime())) {
+      throw new Error('Invalid date');
+    }
+    return dateObj.toISOString().split('T')[0];
+  } catch (e) {
+    console.error(`Error formatting date: ${date}, error: ${e.message}`);
+    return '';
+  }
+};
+
+// Currency-related helper functions
+
+/**
+ * Formats a number as a currency string
+ */
+export const formatCurrency = (amount: number): string => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount);
+};
+
+// Calculation helper functions
+
+/**
+ * Calculate budget total by type
+ */
+export const calculateBudgetTotal = (
+  budgetData: Array<{ budgeted: number; type: string }>,
+  type: string
+): number => {
+  return budgetData
+    .filter(item => item.type === type)
+    .reduce((total, item) => total + item.budgeted, 0);
+};
+
+/**
+ * Standardizes a date for comparison
+ */
+export const standardizeDateFormat = (dateString: string): string => {
+  try {
+    const parsedDate = new Date(dateString);
+    if (!isNaN(parsedDate.getTime())) {
+      return parsedDate.toISOString().split('T')[0];
+    }
+    return dateString; // Return original if parsing fails
+  } catch (e) {
+    console.error(`Error parsing transaction date: ${dateString}, error: ${e.message}`);
+    return dateString; // Return original if error occurs
+  }
+};

--- a/src/app/transactions/mockData.ts
+++ b/src/app/transactions/mockData.ts
@@ -1,0 +1,98 @@
+import type { Transaction } from './types';
+
+// Sample transaction data (for development purposes)
+export const sampleTransactions: Transaction[] = [
+  {
+    id: '1',
+    date: '2025-05-01',
+    description: 'Monthly Salary',
+    amount: 5000,
+    category: 'Salary',
+    type: 'income',
+  },
+  {
+    id: '2',
+    date: '2025-05-05',
+    description: 'Rent',
+    amount: 1500,
+    category: 'Housing',
+    type: 'expense',
+  },
+  {
+    id: '3',
+    date: '2025-05-08',
+    description: 'Groceries',
+    amount: 150,
+    category: 'Food',
+    type: 'expense',
+  },
+  {
+    id: '4',
+    date: '2025-05-10',
+    description: 'Dining Out',
+    amount: 80,
+    category: 'Food',
+    type: 'expense',
+  },
+  {
+    id: '5',
+    date: '2025-05-12',
+    description: 'Gas',
+    amount: 45,
+    category: 'Transportation',
+    type: 'expense',
+  },
+  {
+    id: '6',
+    date: '2025-05-15',
+    description: 'Internet Bill',
+    amount: 70,
+    category: 'Utilities',
+    type: 'expense',
+  },
+  {
+    id: '7',
+    date: '2025-05-18',
+    description: 'Movie Night',
+    amount: 40,
+    category: 'Entertainment',
+    type: 'expense',
+  },
+  {
+    id: '8',
+    date: '2025-05-20',
+    description: 'Investment Return',
+    amount: 200,
+    category: 'Investments',
+    type: 'income',
+  },
+  {
+    id: '9',
+    date: '2025-05-22',
+    description: 'Phone Bill',
+    amount: 60,
+    category: 'Utilities',
+    type: 'expense',
+  },
+  {
+    id: '10',
+    date: '2025-05-24',
+    description: 'Groceries',
+    amount: 120,
+    category: 'Food',
+    type: 'expense',
+  },
+];
+
+// Category lists
+export const incomeCategories = ['Salary', 'Investments', 'Bonus', 'Gifts', 'Other Income'];
+export const expenseCategories = [
+  'Housing',
+  'Food',
+  'Transportation',
+  'Utilities',
+  'Entertainment',
+  'Healthcare',
+  'Shopping',
+  'Other Expenses',
+];

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -144,10 +144,7 @@ export default function TransactionsPage() {
 
   // Get current month transactions
   const currentMonthTransactions = useMemo(() => {
-    console.log('Recalculating currentMonthTransactions with transactions:', transactions);
-    const filtered = transactions.filter(transaction => isCurrentMonth(transaction.date));
-    console.log('Current month transactions:', filtered);
-    return filtered;
+    return transactions.filter(transaction => isCurrentMonth(transaction.date));
   }, [transactions]);
 
   // Generate chart data

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,0 +1,625 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import {
+  isCurrentMonth,
+  formatCurrency,
+  formatDateToISOString,
+  calculateBudgetTotal,
+  standardizeDateFormat,
+} from './helpers';
+import type { Transaction, BudgetCategory, ChartDataPoint } from './types';
+import { sampleTransactions, incomeCategories, expenseCategories } from './mockData';
+import { sampleBudgetData } from '../budget/mockData';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  Legend,
+} from 'recharts';
+import styles from './transactions.module.css';
+
+export default function TransactionsPage() {
+  const [budgetData] = useState<BudgetCategory[]>(sampleBudgetData);
+  const [transactions, setTransactions] = useState<Transaction[]>(sampleTransactions);
+
+  const [newTransaction, setNewTransaction] = useState<Omit<Transaction, 'id'>>({
+    date: new Date().toISOString().split('T')[0],
+    description: '',
+    amount: 0,
+    category: '',
+    type: 'expense',
+  });
+
+  const [filter, setFilter] = useState({
+    type: 'all',
+    category: 'all',
+    startDate: '',
+    endDate: '',
+    searchTerm: '',
+  });
+
+  const addTransaction = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!newTransaction.description || !newTransaction.category || newTransaction.amount <= 0) {
+      alert('Please fill in all fields with valid values');
+      return;
+    }
+    // Ensure the date is in the ISO format YYYY-MM-DD
+    const formattedDate = formatDateToISOString(newTransaction.date);
+
+    const transaction: Transaction = {
+      id: Date.now().toString(),
+      ...newTransaction,
+      date: formattedDate, // Use the standardized date format
+    };
+
+    setTransactions(transactions => [transaction, ...transactions]);
+
+    setNewTransaction({
+      date: new Date().toISOString().split('T')[0],
+      description: '',
+      amount: 0,
+      category: '',
+      type: 'expense',
+    });
+  };
+
+  const removeTransaction = (id: string) => {
+    setTransactions(transactions.filter(transaction => transaction.id !== id));
+  };
+
+  const getUniqueCategories = () => {
+    const categories = transactions.map(transaction => transaction.category);
+    return ['all', ...new Set(categories)];
+  };
+
+  // Function to filter transactions
+  const getFilteredTransactions = () => {
+    return transactions.filter(transaction => {
+      // Filter by type
+      if (filter.type !== 'all' && transaction.type !== filter.type) {
+        return false;
+      }
+
+      // Filter by category
+      if (filter.category !== 'all' && transaction.category !== filter.category) {
+        return false;
+      }
+
+      // Standardize date format for comparison
+      const transactionDate = standardizeDateFormat(transaction.date);
+
+      // Filter by date range
+      if (filter.startDate && transactionDate < filter.startDate) {
+        return false;
+      }
+
+      if (filter.endDate && transactionDate > filter.endDate) {
+        return false;
+      }
+
+      // Filter by search term
+      if (
+        filter.searchTerm &&
+        !transaction.description.toLowerCase().includes(filter.searchTerm.toLowerCase())
+      ) {
+        return false;
+      }
+
+      // For debugging
+      if (isCurrentMonth(transaction.date)) {
+        console.log('Including transaction in filtered results:', transaction);
+      }
+
+      return true;
+    });
+  };
+
+  // Get filtered transactions
+  const filteredTransactions = getFilteredTransactions();
+
+  // Calculate totals
+  const calculateTotal = (type: 'income' | 'expense' | 'all') => {
+    return filteredTransactions
+      .filter(transaction => type === 'all' || transaction.type === type)
+      .reduce((total, transaction) => {
+        return total + transaction.amount;
+      }, 0);
+  };
+
+  // Wrapper for the calculateBudgetTotal helper
+  const calculateBudgetTotalMemo = useCallback(
+    (type: 'income' | 'expense') => {
+      return calculateBudgetTotal(budgetData, type);
+    },
+    [budgetData]
+  );
+
+  // Get current month transactions
+  const currentMonthTransactions = useMemo(() => {
+    console.log('Recalculating currentMonthTransactions with transactions:', transactions);
+    const filtered = transactions.filter(transaction => isCurrentMonth(transaction.date));
+    console.log('Current month transactions:', filtered);
+    return filtered;
+  }, [transactions]);
+
+  // Generate chart data
+  const chartData = useMemo(() => {
+    const totalMonthlyBudget = calculateBudgetTotalMemo('expense');
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = today.getMonth();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const dailyBudget = totalMonthlyBudget / daysInMonth;
+    const transactionsByDate: Record<string, { income: number; expenses: number }> = {};
+    const allDates: string[] = [];
+    const lastDayOfMonth = new Date(year, month + 1, 0);
+
+    // Generate dates for exactly this month
+    for (let day = 1; day <= lastDayOfMonth.getDate(); day++) {
+      // Create a string in YYYY-MM-DD format for this day
+      // Ensure month is zero-padded (May = 05)
+      const monthStr = String(month + 1).padStart(2, '0');
+      // Ensure day is zero-padded
+      const dayStr = String(day).padStart(2, '0');
+      // Create date in YYYY-MM-DD format
+      const dateString = `${year}-${monthStr}-${dayStr}`;
+
+      // Add to our dates array
+      allDates.push(dateString);
+
+      // Initialize transaction data for this date
+      transactionsByDate[dateString] = { income: 0, expenses: 0 };
+    }
+
+    // Fill in actual transaction values
+    currentMonthTransactions.forEach(transaction => {
+      const dateString = transaction.date;
+
+      if (transactionsByDate[dateString]) {
+        if (transaction.type === 'income') {
+          transactionsByDate[dateString].income += transaction.amount;
+        } else {
+          transactionsByDate[dateString].expenses += transaction.amount;
+        }
+      } else {
+        // Try to parse and format the date to match
+        try {
+          const transactionDate = new Date(dateString);
+          const formattedDate = transactionDate.toISOString().split('T')[0];
+
+          // If we have this reformatted date in our map, use it
+          if (transactionsByDate[formattedDate]) {
+            if (transaction.type === 'income') {
+              transactionsByDate[formattedDate].income += transaction.amount;
+            } else {
+              transactionsByDate[formattedDate].expenses += transaction.amount;
+            }
+          }
+        } catch (e) {
+          console.error('Error parsing date:', dateString, e);
+        }
+      }
+    });
+
+    // Generate the chart data points with running totals
+    const result: ChartDataPoint[] = [];
+    let runningIncome = 0;
+    let runningExpenses = 0;
+    let cumulativeBudget = 0;
+
+    // Sort dates to ensure chronological order
+    allDates.sort();
+
+    for (const dateString of allDates) {
+      // Get transaction data for this date if it exists, otherwise use zeros
+      const transactionData = transactionsByDate[dateString] || { income: 0, expenses: 0 };
+      const { income, expenses } = transactionData;
+
+      // Update running totals
+      runningIncome += income;
+      runningExpenses += expenses;
+      const netPosition = runningIncome - runningExpenses;
+      cumulativeBudget += dailyBudget;
+
+      result.push({
+        date: dateString,
+        expenses: expenses,
+        income: income,
+        balance: income - expenses, // Daily balance
+        cumulativeBalance: netPosition, // Running net position (income - expenses)
+        budget: cumulativeBudget,
+      });
+    }
+
+    return result;
+  }, [currentMonthTransactions, calculateBudgetTotalMemo]);
+
+  // Calculate budget progress
+  const budgetProgress = useMemo(() => {
+    const totalBudget = calculateBudgetTotalMemo('expense');
+    const totalExpenses = currentMonthTransactions
+      .filter(t => t.type === 'expense')
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    const percentUsed = (totalExpenses / totalBudget) * 100;
+    const isOverBudget = totalExpenses > totalBudget;
+
+    const result = {
+      totalBudget,
+      totalExpenses,
+      percentUsed,
+      isOverBudget,
+      remaining: totalBudget - totalExpenses,
+    };
+    return result;
+  }, [currentMonthTransactions, calculateBudgetTotalMemo]);
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Transactions</h1>
+
+      <div className={styles.budgetChart}>
+        <h2>
+          Budget Tracking:{' '}
+          {new Date(new Date().getFullYear(), new Date().getMonth(), 1).toLocaleDateString(
+            'en-US',
+            { month: 'short', day: 'numeric' }
+          )}
+          {' - '}
+          {new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).toLocaleDateString(
+            'en-US',
+            { month: 'short', day: 'numeric' }
+          )}
+        </h2>
+        <div className={styles.chartContainer}>
+          <ResponsiveContainer width="100%" height={300}>
+            <AreaChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" tickFormatter={date => new Date(date).getDate().toString()} />
+              <YAxis />
+              <Tooltip
+                formatter={(value: number) => [`$${value.toFixed(2)}`, undefined]}
+                labelFormatter={date => new Date(date).toLocaleDateString()}
+              />
+              <Legend />
+              <ReferenceLine y={0} stroke="#000" strokeWidth={1} strokeOpacity={0.5} />
+              <Area
+                type="monotone"
+                dataKey="cumulativeBalance"
+                stroke="#8884d8"
+                fill="#8884d8"
+                fillOpacity={0.2}
+                name="Monthly Net Position (Income - Expenses)"
+                isAnimationActive={true}
+              />
+              <Area
+                type="monotone"
+                dataKey="budget"
+                stroke="#ff0000"
+                strokeDasharray="3 3"
+                fill="#ff0000"
+                fillOpacity={0.1}
+                name="Budget Position"
+                isAnimationActive={true}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className={styles.budgetSummary}>
+          <div
+            className={`${styles.budgetStatus} ${budgetProgress.isOverBudget ? styles.overBudget : styles.underBudget}`}
+          >
+            <h3>{budgetProgress.isOverBudget ? 'Over Budget!' : 'Under Budget'}</h3>
+            <p>You&apos;ve spent {budgetProgress.percentUsed.toFixed(1)}% of your monthly budget</p>
+          </div>
+
+          <div className={styles.budgetDetails}>
+            <div className={styles.budgetDetail}>
+              <span>Monthly Budget:</span>
+              <span>{formatCurrency(budgetProgress.totalBudget)}</span>
+            </div>
+            <div className={styles.budgetDetail}>
+              <span>Spent So Far:</span>
+              <span>{formatCurrency(budgetProgress.totalExpenses)}</span>
+            </div>
+            <div className={styles.budgetDetail}>
+              <span>{budgetProgress.isOverBudget ? 'Amount Over:' : 'Remaining:'}</span>
+              <span>{formatCurrency(Math.abs(budgetProgress.remaining))}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.grid}>
+        {/* Form section */}
+        <div className={styles.formSection}>
+          <h2>Add New Transaction</h2>
+          <form onSubmit={addTransaction} className={styles.form}>
+            <div className={styles.formGroup}>
+              <label htmlFor="type">Type</label>
+              <select
+                id="type"
+                value={newTransaction.type}
+                onChange={e =>
+                  setNewTransaction({
+                    ...newTransaction,
+                    type: e.target.value as 'income' | 'expense',
+                    // Reset category when type changes
+                    category: '',
+                  })
+                }
+                className={styles.select}
+              >
+                <option value="expense">Expense</option>
+                <option value="income">Income</option>
+              </select>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label htmlFor="category">Category</label>
+              <select
+                id="category"
+                value={newTransaction.category}
+                onChange={e =>
+                  setNewTransaction({
+                    ...newTransaction,
+                    category: e.target.value,
+                  })
+                }
+                className={styles.select}
+                required
+              >
+                <option value="">Select a category</option>
+                {newTransaction.type === 'income'
+                  ? incomeCategories.map(category => (
+                      <option key={category} value={category}>
+                        {category}
+                      </option>
+                    ))
+                  : expenseCategories.map(category => (
+                      <option key={category} value={category}>
+                        {category}
+                      </option>
+                    ))}
+              </select>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label htmlFor="date">Date</label>
+              <input
+                type="date"
+                id="date"
+                value={newTransaction.date}
+                onChange={e =>
+                  setNewTransaction({
+                    ...newTransaction,
+                    date: e.target.value,
+                  })
+                }
+                className={styles.input}
+                required
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label htmlFor="description">Description</label>
+              <input
+                type="text"
+                id="description"
+                value={newTransaction.description}
+                onChange={e =>
+                  setNewTransaction({
+                    ...newTransaction,
+                    description: e.target.value,
+                  })
+                }
+                className={styles.input}
+                required
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label htmlFor="amount">Amount</label>
+              <input
+                type="number"
+                id="amount"
+                min="0.01"
+                step="0.01"
+                value={newTransaction.amount || ''}
+                onChange={e =>
+                  setNewTransaction({
+                    ...newTransaction,
+                    amount: parseFloat(e.target.value) || 0,
+                  })
+                }
+                className={styles.input}
+                required
+              />
+            </div>
+
+            <button type="submit" className={styles.button}>
+              Add Transaction
+            </button>
+          </form>
+        </div>
+
+        {/* List section */}
+        <div className={styles.listSection}>
+          <div className={styles.filters}>
+            <h2>Transactions</h2>
+            <div className={styles.filterControls}>
+              <div className={styles.filterGroup}>
+                <label htmlFor="filterType">Type</label>
+                <select
+                  id="filterType"
+                  value={filter.type}
+                  onChange={e =>
+                    setFilter({
+                      ...filter,
+                      type: e.target.value as 'all' | 'income' | 'expense',
+                    })
+                  }
+                  className={styles.filterSelect}
+                >
+                  <option value="all">All</option>
+                  <option value="income">Income</option>
+                  <option value="expense">Expense</option>
+                </select>
+              </div>
+
+              <div className={styles.filterGroup}>
+                <label htmlFor="filterCategory">Category</label>
+                <select
+                  id="filterCategory"
+                  value={filter.category}
+                  onChange={e =>
+                    setFilter({
+                      ...filter,
+                      category: e.target.value,
+                    })
+                  }
+                  className={styles.filterSelect}
+                >
+                  {getUniqueCategories().map(category => (
+                    <option key={category} value={category}>
+                      {category === 'all' ? 'All Categories' : category}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className={styles.filterGroup}>
+                <label htmlFor="searchTerm">Search</label>
+                <input
+                  type="text"
+                  id="searchTerm"
+                  value={filter.searchTerm}
+                  onChange={e =>
+                    setFilter({
+                      ...filter,
+                      searchTerm: e.target.value,
+                    })
+                  }
+                  placeholder="Search descriptions..."
+                  className={styles.filterInput}
+                />
+              </div>
+
+              <div className={styles.dateFilters}>
+                <div className={styles.filterGroup}>
+                  <label htmlFor="startDate">From</label>
+                  <input
+                    type="date"
+                    id="startDate"
+                    value={filter.startDate}
+                    onChange={e =>
+                      setFilter({
+                        ...filter,
+                        startDate: e.target.value,
+                      })
+                    }
+                    className={styles.filterInput}
+                  />
+                </div>
+
+                <div className={styles.filterGroup}>
+                  <label htmlFor="endDate">To</label>
+                  <input
+                    type="date"
+                    id="endDate"
+                    value={filter.endDate}
+                    onChange={e =>
+                      setFilter({
+                        ...filter,
+                        endDate: e.target.value,
+                      })
+                    }
+                    className={styles.filterInput}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.summary}>
+            <div className={styles.summaryItem}>
+              <span>Income:</span>
+              <span className={styles.income}>{formatCurrency(calculateTotal('income'))}</span>
+            </div>
+            <div className={styles.summaryItem}>
+              <span>Expenses:</span>
+              <span className={styles.expense}>{formatCurrency(calculateTotal('expense'))}</span>
+            </div>
+            <div className={styles.summaryItem}>
+              <span>Balance:</span>
+              <span
+                className={
+                  calculateTotal('income') - calculateTotal('expense') >= 0
+                    ? styles.income
+                    : styles.expense
+                }
+              >
+                {formatCurrency(calculateTotal('income') - calculateTotal('expense'))}
+              </span>
+            </div>
+          </div>
+
+          {filteredTransactions.length === 0 ? (
+            <div className={styles.noTransactions}>
+              <p>No transactions found matching your filters.</p>
+            </div>
+          ) : (
+            <div className={styles.transactionList}>
+              {filteredTransactions.map(transaction => (
+                <div
+                  key={transaction.id}
+                  className={`${styles.transactionItem} ${
+                    transaction.type === 'income' ? styles.incomeItem : styles.expenseItem
+                  }`}
+                >
+                  <div className={styles.transactionHeader}>
+                    <span className={styles.transactionDate}>{transaction.date}</span>
+                    <span
+                      className={`${styles.transactionCategory} ${
+                        transaction.type === 'income'
+                          ? styles.incomeCategory
+                          : styles.expenseCategory
+                      }`}
+                    >
+                      {transaction.category}
+                    </span>
+                  </div>
+
+                  <div className={styles.transactionDetails}>
+                    <span className={styles.transactionDescription}>{transaction.description}</span>
+                    <span className={styles.transactionAmount}>
+                      {transaction.type === 'income' ? '+' : '-'}{' '}
+                      {formatCurrency(transaction.amount)}
+                    </span>
+                  </div>
+
+                  <button
+                    className={styles.deleteButton}
+                    onClick={() => removeTransaction(transaction.id)}
+                    aria-label="Delete transaction"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/transactions/transactions.module.css
+++ b/src/app/transactions/transactions.module.css
@@ -1,0 +1,353 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+/* Budget Chart Section */
+.budgetChart {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.chartContainer {
+  margin: 1.5rem 0;
+  border: 1px solid #f0f0f0;
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+.budgetSummary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.budgetStatus {
+  padding: 1.25rem;
+  border-radius: 8px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.budgetStatus h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.25rem;
+}
+
+.budgetStatus p {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.underBudget {
+  background-color: rgba(40, 167, 69, 0.1);
+  color: #28a745;
+}
+
+.overBudget {
+  background-color: rgba(220, 53, 69, 0.1);
+  color: #dc3545;
+}
+
+.budgetDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.budgetDetail {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.budgetDetail:last-child {
+  border-bottom: none;
+  font-weight: bold;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .budgetSummary {
+    grid-template-columns: 1fr;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Form Section */
+.formSection {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.formGroup label {
+  font-weight: 500;
+  color: #333;
+}
+
+.input,
+.select {
+  padding: 0.75rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: #0070f3;
+}
+
+.button {
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  margin-top: 1rem;
+}
+
+.button:hover {
+  background-color: #0060df;
+}
+
+/* List Section */
+.listSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.filters {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+}
+
+.filterControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.filterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 150px;
+}
+
+.filterGroup label {
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.filterInput,
+.filterSelect {
+  padding: 0.5rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.dateFilters {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.dateFilters .filterGroup {
+  flex: 1;
+}
+
+/* Summary */
+.summary {
+  display: flex;
+  justify-content: space-between;
+  background-color: #f8f9fa;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+.summaryItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.summaryItem span:first-child {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.summaryItem span:last-child {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.income {
+  color: #28a745;
+}
+
+.expense {
+  color: #dc3545;
+}
+
+/* Transaction List */
+.transactionList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 600px;
+  overflow-y: auto;
+}
+
+.transactionItem {
+  position: relative;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+  transition: transform 0.2s ease;
+}
+
+.transactionItem:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.15);
+}
+
+.incomeItem {
+  border-left: 4px solid #28a745;
+}
+
+.expenseItem {
+  border-left: 4px solid #dc3545;
+}
+
+.transactionHeader {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.transactionDate {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.transactionCategory {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.incomeCategory {
+  background-color: rgba(40, 167, 69, 0.1);
+  color: #28a745;
+}
+
+.expenseCategory {
+  background-color: rgba(220, 53, 69, 0.1);
+  color: #dc3545;
+}
+
+.transactionDetails {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.transactionDescription {
+  font-weight: 500;
+  color: #333;
+}
+
+.transactionAmount {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.deleteButton {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  color: #777;
+  font-size: 1.25rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.transactionItem:hover .deleteButton {
+  opacity: 1;
+}
+
+.deleteButton:hover {
+  color: #dc3545;
+}
+
+.noTransactions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f8f9fa;
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  color: #666;
+}

--- a/src/app/transactions/types.ts
+++ b/src/app/transactions/types.ts
@@ -1,0 +1,25 @@
+// Transaction-related types
+
+export type Transaction = {
+  id: string;
+  date: string;
+  description: string;
+  amount: number;
+  category: string;
+  type: 'income' | 'expense';
+};
+
+export type BudgetCategory = {
+  category: string;
+  budgeted: number;
+  type: 'income' | 'expense';
+};
+
+export type ChartDataPoint = {
+  date: string;
+  expenses: number;
+  income: number;
+  balance: number;
+  cumulativeBalance: number;
+  budget: number;
+};

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -1,0 +1,47 @@
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: #ffffff;
+  border-bottom: 1px solid #e0e0e0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.logo a {
+  color: #0070f3;
+  text-decoration: none;
+}
+
+.links {
+  display: flex;
+  list-style: none;
+  gap: 2rem;
+  margin: 0;
+  padding: 0;
+}
+
+.links li a {
+  text-decoration: none;
+  color: #333;
+  font-weight: 500;
+  padding: 0.5rem;
+  transition: color 0.2s ease;
+}
+
+.links li a:hover {
+  color: #0070f3;
+}
+
+.links li a.active {
+  color: #0070f3;
+  border-bottom: 2px solid #0070f3;
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import styles from './Navigation.module.css';
+
+export default function Navigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav className={styles.nav}>
+      <div className={styles.logo}>
+        <Link href="/">Balanced</Link>
+      </div>
+      <ul className={styles.links}>
+        <li>
+          <Link href="/" className={pathname === '/' ? styles.active : ''}>
+            Home
+          </Link>
+        </li>
+        <li>
+          <Link href="/budget" className={pathname === '/budget' ? styles.active : ''}>
+            Budget
+          </Link>
+        </li>
+        <li>
+          <Link href="/transactions" className={pathname === '/transactions' ? styles.active : ''}>
+            Transactions
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## What is the purpose of this pull request?

- Add budget page
- Add transactions page
- Add navigation component
- Add mock data for budget and transactions
- Add pre-commit typecheck
- Add recharts package for graph on transactions page

## Why is this change necessary?

- Showing and allowing a user to enter and delete transactions and budget elements are features of the app, adding theses means the user can work out if they are staying within budget for the month
 
## How can we test and review this pull request?

- Run the application, there should now be a navigation bar which will help navigation to the transaction and budget pages, entering values on these pages will update the subtotals and values shown
- The graph is showing for the current month, so should be showing a date range from the first to the last of the month.

## What are the next 

- Currently the budget on the graph is not dynamic to the users budget, but using mock data, and should be updated.